### PR TITLE
added a std::floor() to the coords on the player tab

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -172,7 +172,7 @@ namespace DX11_Base
                 if (Config.GetPalPlayerCharacter()->GetPalPlayerController() != NULL)
                 {
                     SDK::FVector PlayerLocation = p_appc->K2_GetActorLocation();
-                    std::string MyLocation = std::format("X: {} | Y: {} | Z: {}", PlayerLocation.X, PlayerLocation.Y, PlayerLocation.Z);
+                    std::string MyLocation = std::format("X: {} | Y: {} | Z: {}", floor(PlayerLocation.X), floor(PlayerLocation.Y), floor(PlayerLocation.Z));
                     ImGui::Text(MyLocation.c_str());
                     if (ImGui::Button("Print Coords", ImVec2(ImGui::GetContentRegionAvail().x - 3, 20)))
                         g_Console->printdbg(MyLocation.c_str(), Console::Colors::green, p_appc);


### PR DESCRIPTION
added a std::floor() to the coords on the player tab to fix the window size spam when on a mount