### PR TITLE
Fixed crash caused by mismatched ImgGui Begin and End

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -871,7 +871,7 @@ namespace DX11_Base
         if (Config.isDebugESP)
             ESP_DEBUG(Config.mDebugESPDistance);
 
-        //ImGui::End();
+        ImGui::End();
 	}
 
     void Menu::Loops()


### PR DESCRIPTION
Menu.cpp had ImgGui::End() commented out causing a crash when pressing insert to close the menu