### PR TITLE
Added warning about incompatibility with other programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Simple internal built with various code snippets and SDK from UC.me
 > [!Note]
 > Built for Steam release v0.1.4.1
 
+>[!Warning]
+>Incompatible with other programs and overlays which also access the game. 
+>For example:
+>- blitz.gg
+
 ## Steps to Build
 
 This assumes you have Visual Studio 2022 installed


### PR DESCRIPTION
As I just found out after half an hour of debugging, blitz.gg also hooks into Palworld for its integration. 
`'Palworld-Win64-Shipping.exe' (Win32): Loaded 'C:\Users\xyz\AppData\Roaming\Blitz\blitz-deps\2.1.124\blitz_palworld.dll'. `

This causes an immediate crash to desktop if you try to inject the NetCrack.dll

