### PR TITLE
Add filter for rare/lucky pals

### DIFF
--- a/config.h
+++ b/config.h
@@ -31,6 +31,7 @@ public:
 	bool bisOpenManager = false;
 	bool filterPlayer = false;
 	bool filterPal = false;
+	bool filterLuckyPal = false;
 	bool isfilterSelf = true;
 	bool bisRandomName = false;
 	bool bisTeleporter = false;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -718,7 +718,10 @@ namespace DX11_Base
             ImGui::Checkbox("Player", &Config.filterPlayer);
             ImGui::SameLine();
             ImGui::Checkbox("Pal", &Config.filterPal);
+            ImGui::SameLine();
+            ImGui::Checkbox("Lucky Pal", &Config.filterLuckyPal);
             SDK::TArray<SDK::AActor*> T = Config.GetUWorld()->PersistentLevel->Actors;
+
             for (int i = 0; i < T.Count(); i++)
             {
                 if (!T[i])
@@ -753,6 +756,13 @@ namespace DX11_Base
                 if (Config.filterPal)
                 {
                     if (!Character->StaticCharacterParameterComponent->IsPal)
+                    {
+                        continue;
+                    }
+                }
+                if (Config.filterLuckyPal)
+                {
+                    if (!Character->StaticCharacterParameterComponent->IsRarePal())
                     {
                         continue;
                     }


### PR DESCRIPTION
Adds a filter to show nearby lucky pals.

This function needs to be reworked. I observed the following issues in the current `master` branch:

- If there are no filters, the pal names are their code names. If the pal filter is checked, the pal names are their friendly names.
- Checking multiple or all filters yields non-expected results. Eg. if all filters are applied, the entity list is empty.

This PR would introduce more issues with filtering. Additionally, maybe this does not have to be a separate tab. It might be better to prepend pal names with `**` or `(Lucky)` to denote that they are rare spawns.