### PR TITLE
Minor change to entity filters

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -757,7 +757,7 @@ namespace DX11_Base
                         continue;
                     }
                 }
-                if (T[i]->IsA(SDK::APalPlayerCharacter::StaticClass()))
+                if (T[i]->IsA(SDK::APalPlayerCharacter::StaticClass()) || Character->StaticCharacterParameterComponent->IsPal)
                 {
                     if (!Character)
                         continue;
@@ -787,14 +787,12 @@ namespace DX11_Base
                         name = SDK::FString(ws);
                     }
                 }
-                if (Config.filterPal)
-                {
-                    if (Character->StaticCharacterParameterComponent->IsPal)
-                    {
-                        Character->CharacterParameterComponent->GetNickname(&name);
-                    }
-                }
-                ImGui::Text(name.ToString().c_str());
+                ImGui::Text(
+                    "%s%s%s",
+                    Character->StaticCharacterParameterComponent->IsRarePal() ? "** " : "",
+                    name.ToString().c_str(),
+                    Character->StaticCharacterParameterComponent->IsRarePal() ? " **" : ""
+                );
                 ImGui::SameLine();
                 ImGui::PushID(i);
                 if (ImGui::Button("Kill"))


### PR DESCRIPTION
Added some minor changes to entity list.

1) When pal is unchecked it will show the correct pal name we know ingame. Wont show PinkCat when its supposed to be Cattiva etc..

2) Added bycEEE rare / lucky filter. Didn't add his checkbox but instead incorporated it into pal names itself.

Should come out as ** Pal ** <-- Meaning Lucky can make it more fancy by adding colors or changing ** to something else entirely.

Didnt work on fixing multiple checkboxes set problem.